### PR TITLE
Added interrupt features, and an efficient micros function.

### DIFF
--- a/Core/Inc/ACDC_INTERRUPT.h
+++ b/Core/Inc/ACDC_INTERRUPT.h
@@ -20,6 +20,20 @@ typedef enum{
     TT_RISING_AND_FALLING_EDGE = 0b11  /**< Interrupt Occurs on both the Rising and Falling Edges */
 } GPIO_TriggerType;
 
+/// @brief Enables Interrupts for the specific vector IRQn
+/// @param IRQn Interrupt vector to enable
+void INTERRUPT_Enable(IRQn_Type IRQn);
+
+/// @brief Disables Interrupts for the specific vector IRQn
+/// @param IRQn Interrupt vector to disable
+void INTERRUPT_Disable(IRQn_Type IRQn);
+
+/// @brief Sets the priority of the Interrupt vector IRQn. (0-15, A lower value means higher priority)
+/// @param IRQn Interrupt vector
+/// @param PreemptPriority Preempt Priority of the IRQn vector (Value: 0-15 Lower value means higher priority)
+/// @param SubPriority SubPriority of the IRQn vector (Value 0-15 Lower value means higher priority)
+void INTERRUPT_SetPriority(IRQn_Type IRQn, uint8_t Priority);
+
 /// @brief Enables Interrupts for GPIO_PIN on GPIOx. (Make sure to set GPIO_PIN as an Input)
 /// @param GPIOx Port of the GPIO (Ex. GPIOA, GPIOB, ...) 
 /// @param GPIO_PIN Desired pin on port GPIOx (Ex. GPIO_PIN_0, GPIO_PIN_1, ...)

--- a/Core/Inc/ACDC_INTERRUPT.h
+++ b/Core/Inc/ACDC_INTERRUPT.h
@@ -28,10 +28,9 @@ void INTERRUPT_Enable(IRQn_Type IRQn);
 /// @param IRQn Interrupt vector to disable
 void INTERRUPT_Disable(IRQn_Type IRQn);
 
-/// @brief Sets the priority of the Interrupt vector IRQn. (0-15, A lower value means higher priority)
+/// @brief Sets the priority of the Interrupt vector IRQn.
 /// @param IRQn Interrupt vector
-/// @param PreemptPriority Preempt Priority of the IRQn vector (Value: 0-15 Lower value means higher priority)
-/// @param SubPriority SubPriority of the IRQn vector (Value 0-15 Lower value means higher priority)
+/// @param Priority Priority of the IRQn vector (Value: 0-15 Lower value means higher priority)
 void INTERRUPT_SetPriority(IRQn_Type IRQn, uint8_t Priority);
 
 /// @brief Enables Interrupts for GPIO_PIN on GPIOx. (Make sure to set GPIO_PIN as an Input)

--- a/Core/Inc/ACDC_TIMER.h
+++ b/Core/Inc/ACDC_TIMER.h
@@ -27,9 +27,13 @@ void TIMER_Init(SystemClockSpeed SCS_x);
 /// @param SCS_x System Clock Speed (Ex. SCS_72Mhz, SCS_36Mhz, ...)
 void TIMER_SetSystemClockSpeed(SystemClockSpeed SCS_x);
 
-/// @brief Grabs and returns the total number of milliseconds since the Micro turned on
+/// @brief Grabs and returns the total number of milliseconds since the MCU turned on
 /// @return Number of milliseconds since startup
 uint64_t Millis();
+
+/// @brief Grabs and returns the total number of microseconds since the MCU turned on
+/// @return Number of microseconds since startup
+uint64_t Micros();
 
 /// @brief Pauses code execution for delayVal number of milliseconds
 /// @param delayVal Number of milliseconds to delay for

--- a/Core/Src/ACDC_INTERRUPT.c
+++ b/Core/Src/ACDC_INTERRUPT.c
@@ -21,20 +21,56 @@
 #include "ACDC_INTERRUPT.h"
 #include "ACDC_GPIO.h"
 
-void GPIO_INT_SetToInterrupt(const GPIO_TypeDef *GPIOx, uint16_t GPIO_PIN, GPIO_TriggerType triggerType){
-    //External Interrupts are Muxed so you can only use 16 concurrently {See RM-210}
+void INTERRUPT_Enable(IRQn_Type IRQn){
+    // Enables Specific Interrupt Vectors {See PM-120}
+    if(IRQn >= 0){
+        uint8_t index = IRQn >> 5;                      // Get the index of the IRQ {0-31 = 0, 32-63 = 1}
+        uint8_t irqToEnable = 0b1 << (IRQn & 0x1F);     // Shift the set bit down 0-31 places
+        SET_BIT(NVIC->ISER[index], irqToEnable);        // Set the bit to enable the IRQn interrupt vector
+    }
+}
+
+void INTERRUPT_Disable(IRQn_Type IRQn){
+    // Disables Specific Interrupt Vectors {See PM-121}
+    if(IRQn >= 0){
+        uint8_t index = IRQn >> 5;                      // Get the index of the IRQ {0-31 = 0, 32-63 = 1}
+        uint8_t irqToDisable = 0b1 << (IRQn & 0x1F);    // Shift the set bit down 0-31 places
+        SET_BIT(NVIC->ICER[index], irqToDisable);       // Set the bit to disable the IRQn interrupt vector
+    }
+}
+
+void INTERRUPT_SetPriority(IRQn_Type IRQn, uint8_t Priority){
+    // IRQn values >= 0 are STM32 specific interrupt vectors
+    // IRQn values < 0 are Cortex-M3 specific interrupt vectors
+    // IRQn values -13 & -14 cannot change their priorities (HardFault_IRQn , NonMaskableInt_IRQn) {See PM-33}
+
+    const uint8_t STM32_LOWEST_INT_VECTOR = WWDG_IRQn;                              // Lowest STM32 specific interrupt vector
+    const uint8_t CORTEX_M3_SCB_SHP_OFFSET = 12;                                    // Offset used to convert a interrupt vector into a SCB->SHPR index. {See PM-138, PM-139, PM-140} 
+    const int8_t CORTEX_M3_LOWEST_CONFIGURABLE_INT_VECTOR = MemoryManagement_IRQn;  // Lowest configurable Cortex-M3 vector
+    uint8_t calcPriority = (Priority << 4) & 0xFF;                                  // The processor implements bits [7:4], bits [3:0] are 0 and ignore writes {See PM-125}
+
+    if(IRQn >= STM32_LOWEST_INT_VECTOR)                                     // If it is a STM32 specific interrupt vector
+        WRITE_REG(NVIC->IP[IRQn], calcPriority);                            // Write the calculated priority to the register
+    else if(IRQn >= CORTEX_M3_LOWEST_CONFIGURABLE_INT_VECTOR)               // If it is a configurable Cortex-M3 interrupt vector
+        WRITE_REG(SCB->SHP[CORTEX_M3_SCB_SHP_OFFSET], calcPriority);        // Write the calcualted priority to the SCB->SHP register
+}
+
+
+void GPIO_INT_SetToInterrupt(const GPIO_TypeDef *GPIOx, uint16_t GPIO_PIN, GPIO_TriggerType TT_x){
+    //External Interrupts are Muxed so you can only use 16 concurrently {See Page 210 RM}
+    //https://community.st.com/t5/stm32-mcus-products/nvic-interrupts-on-two-ports-with-same-pin-number/td-p/550469
 
     RCC->APB2ENR |= RCC_APB2ENR_AFIOEN; //Enable Alternate Functions (Needed for Interrupts)
 
     uint16_t pin = GPIO_GetPinNumber(GPIO_PIN);
     EXTI->IMR |= 1 << pin;        //Enable Interrupts on pin
-    if(triggerType & TT_RISING_EDGE)
+    if(TT_x & TT_RISING_EDGE)
         EXTI->RTSR |= 1 << pin;   //Enable RisingEdge Interrupts on pin
-    if(triggerType & TT_FALLING_EDGE)
+    if(TT_x & TT_FALLING_EDGE)
         EXTI->FTSR |= 1 << pin;   //Enable FallingEdge Interrupts on pin
 
     uint16_t CRNumber = pin >> 2; //Gets the EXTICRx number
-    uint16_t GpioMask = 0;        //Gets the GPIO mask {See RM-191}
+    uint16_t GpioMask;            //Gets the GPIO mask {See RM-191}
     if(GPIOx == GPIOA)
         GpioMask = 0b0000;
     else if(GPIOx == GPIOB)

--- a/Core/Src/ACDC_INTERRUPT.c
+++ b/Core/Src/ACDC_INTERRUPT.c
@@ -60,20 +60,18 @@ void GPIO_INT_SetToInterrupt(const GPIO_TypeDef *GPIOx, uint16_t GPIO_PIN, GPIO_
     //External Interrupts are Muxed so you can only use 16 concurrently {See Page 210 RM}
     //https://community.st.com/t5/stm32-mcus-products/nvic-interrupts-on-two-ports-with-same-pin-number/td-p/550469
 
-    RCC->APB2ENR |= RCC_APB2ENR_AFIOEN; //Enable Alternate Functions (Needed for Interrupts)
+    RCC->APB2ENR |= RCC_APB2ENR_AFIOEN; // Enable Alternate Functions (Needed for Interrupts)
 
     uint16_t pin = GPIO_GetPinNumber(GPIO_PIN);
-    EXTI->IMR |= 1 << pin;        //Enable Interrupts on pin
+    EXTI->IMR |= 1 << pin;        // Enable Interrupts on pin
     if(TT_x & TT_RISING_EDGE)
-        EXTI->RTSR |= 1 << pin;   //Enable RisingEdge Interrupts on pin
+        EXTI->RTSR |= 1 << pin;   // Enable RisingEdge Interrupts on pin
     if(TT_x & TT_FALLING_EDGE)
-        EXTI->FTSR |= 1 << pin;   //Enable FallingEdge Interrupts on pin
+        EXTI->FTSR |= 1 << pin;   // Enable FallingEdge Interrupts on pin
 
-    uint16_t CRNumber = pin >> 2; //Gets the EXTICRx number
-    uint16_t GpioMask;            //Gets the GPIO mask {See RM-191}
-    if(GPIOx == GPIOA)
-        GpioMask = 0b0000;
-    else if(GPIOx == GPIOB)
+    uint16_t CRNumber = pin >> 2; // Gets the EXTICRx number
+    uint16_t GpioMask = 0b0000;   // default to GPIOA (GPIO mask {See RM-191})
+    if(GPIOx == GPIOB)
         GpioMask = 0b0001;
     else if(GPIOx == GPIOC)
         GpioMask = 0b0010;

--- a/Core/Src/ACDC_INTERRUPT.c
+++ b/Core/Src/ACDC_INTERRUPT.c
@@ -52,7 +52,7 @@ void INTERRUPT_SetPriority(IRQn_Type IRQn, uint8_t Priority){
     if(IRQn >= STM32_LOWEST_INT_VECTOR)                                     // If it is a STM32 specific interrupt vector
         WRITE_REG(NVIC->IP[IRQn], calcPriority);                            // Write the calculated priority to the register
     else if(IRQn >= CORTEX_M3_LOWEST_CONFIGURABLE_INT_VECTOR)               // If it is a configurable Cortex-M3 interrupt vector
-        WRITE_REG(SCB->SHP[CORTEX_M3_SCB_SHP_OFFSET], calcPriority);        // Write the calcualted priority to the SCB->SHP register
+        WRITE_REG(SCB->SHP[IRQn + CORTEX_M3_SCB_SHP_OFFSET], calcPriority); // Write the calcualted priority to the SCB->SHP register
 }
 
 

--- a/Core/Src/ACDC_TIMER.c
+++ b/Core/Src/ACDC_TIMER.c
@@ -9,18 +9,23 @@
  */
 
 #include "ACDC_TIMER.h"
+#include "ACDC_INTERRUPT.h"
 #include "stm32f1xx.h"
 
-#define MS_PER_SECOND 1000
+#define MS_PER_SECOND 1000  // Number of milliseconds per second
+#define US_PER_MS     1000  // Number of microseconds per millisecond
 
 volatile static uint64_t SysTickCounter;
+static uint8_t SCS_IN_MHz;                  // Clock frequency in MHz (SCS_72Mhz -> 72, SCS_36Mhz -> 36, Etc.)
 
 void TIMER_Init(SystemClockSpeed SCS_x){  //TODO: Should only ever be called once (Need to add an assert)
     SysTick->CTRL |= SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_ENABLE_Msk | SysTick_CTRL_TICKINT_Msk;
     TIMER_SetSystemClockSpeed(SCS_x);
+    INTERRUPT_SetPriority(SysTick_IRQn, 0);
 }
 
 void TIMER_SetSystemClockSpeed(SystemClockSpeed SCS_x){
+    SCS_IN_MHz = SCS_x / MS_PER_SECOND / US_PER_MS;     // Divide by 1,000,000 (72MHz -> 72)
     SysTick->LOAD = ((SCS_x / MS_PER_SECOND) - 1) & SysTick_LOAD_RELOAD_Msk;
 }
 
@@ -30,6 +35,11 @@ void SysTick_Handler(void){
 
 uint64_t Millis(){
     return SysTickCounter;
+}
+
+uint64_t Micros(){
+    uint32_t numSysTicks = 1000 - (SysTick->VAL / SCS_IN_MHz);   // Current number of ticks in the value register (SysTick counts down from SysTick->LOAD)
+    return (SysTickCounter * US_PER_MS) + numSysTicks;           // Gets the total number of us from startup (MS * 1000) + us 
 }
 
 void Delay(uint64_t delayVal){

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -27,16 +27,15 @@ static void ACDC_Init(SystemClockSpeed SCS_x);
 int main(void)
 {
   ACDC_Init(SCS_72MHz);
-  LTCADC_InitCS(SPI2, GPIOB, GPIO_PIN_1);
 
-  uint16_t oldData = 0;
+  uint64_t oldTime = Micros();
 
   while (1)
   {
-    uint32_t newData = LTCADC_ReadCH0CS(SPI2, GPIOB, GPIO_PIN_1);
-    if(newData != oldData){
-      USART_SendString(USART2, StringConvert(newData)); 
-      oldData = newData;
+    if(Micros() - oldTime >= 1000000){      // 1,000,000us per second     
+      oldTime = Micros();                   // Update time at the top of the if to prevent drifting
+      USART_SendString(USART2, "UART MSG"); // Send a UART messages
+      GPIO_Toggle(GPIOA, GPIO_PIN_5);       // Toggle the LED
     }
   }
 }

--- a/Docs/INTERRUPT.md
+++ b/Docs/INTERRUPT.md
@@ -29,3 +29,48 @@ void EXTI15_10_IRQHandler(void)
     }
 }
 ```
+
+
+## Set the GPIO interrupt to the lowest priority (highest number)
+
+```C
+#include "ACDC_GPIO.h"
+
+//Green LED   => GPIOA, PIN 5
+//Blue Button => GPIOC, PIN 13
+
+int main(){
+    //Set Green Led to ouput, Blue Button to Input W/ Pullup resistor, and enable External Interrupts
+    GPIO_PinDirection(GPIOA, GPIO_PIN_5 , GPIO_MODE_OUTPUT_SPEED_2MHz, GPIO_CNF_OUTPUT_PUSH_PULL);
+    GPIO_PinDirection(GPIOC, GPIO_PIN_13, GPIO_MODE_INPUT            , GPIO_CNF_INPUT_PULLUP    );
+    GPIO_INT_SetToInterrupt(GPIOC, GPIO_PIN_13, RISING_EDGE);
+    INTERRUPT_SetPriority(EXTI15_10_IRQn, 15);  // Lowest priority available
+
+    while(1){}
+}
+```
+
+## Show how to enable or disable a specific interrupt vector
+
+```C
+#include "ACDC_GPIO.h"
+
+//Green LED   => GPIOA, PIN 5
+//Blue Button => GPIOC, PIN 13
+
+int main(){
+    //Set Green Led to ouput, Blue Button to Input W/ Pullup resistor, and enable External Interrupts
+    GPIO_PinDirection(GPIOA, GPIO_PIN_5 , GPIO_MODE_OUTPUT_SPEED_2MHz, GPIO_CNF_OUTPUT_PUSH_PULL);
+    GPIO_PinDirection(GPIOC, GPIO_PIN_13, GPIO_MODE_INPUT            , GPIO_CNF_INPUT_PULLUP    );
+    GPIO_INT_SetToInterrupt(GPIOC, GPIO_PIN_13, RISING_EDGE);
+    INTERRUPT_SetPriority(EXTI15_10_IRQn, 15);  // Lowest priority available
+
+
+    bool iWantToDisableLedInterrupt = true;
+    while(1){
+        if(iWantToDisableLedInterrupt)
+            INTERRUPT_Disable(EXTI15_10_IRQn);
+        else
+            INTERRUPT_Enable(EXTI15_10_IRQn);
+    }
+}

--- a/Docs/TIMER.md
+++ b/Docs/TIMER.md
@@ -42,9 +42,36 @@ int main(){
     uint32_t previousTime = Millis();   //Grab the number of milliseconds since startup
 
     while(1){
-        if(Millis() - previousTime >= 1000){
-            GPIO_Toggle(GPIOA, GPIO_PIN_5);
-            previousTime = Millis();
+        if(Millis() - previousTime >= 1000){    // 1,000ms per second
+            previousTime = Millis();            // Update this first to keep accurate timing
+            GPIO_Toggle(GPIOA, GPIO_PIN_5);     // (else it will drift because of the time it takes to call GPIO_Toggle)
+        }
+    }
+
+}
+```
+
+## Use the Micros function to toggle a LED every second
+
+```C
+#include "ACDC_TIMER.h"
+#include "ACDC_CLOCK.h"
+
+//Green LED => GPIOA, GPIO_PIN_5
+
+int main(){
+
+    CLOCK_SetSystemClockSpeed(SCS_72MHz);   //Set the SysClock to 72MHz (CALLS TIMER_Init)
+    CLOCK_SetAPB1Prescaler(APB_DIV_2);      //Set the APB1 Prescaler to /2
+
+    GPIO_PinDirection(GPIOA, GPIO_PIN_5, GPIO_MODE_OUTPUT_2MHz, GPIO_CNF_OUTPUT_PUSH_PULL);   //Set the Green LED to an output
+
+    uint64_t previousTime = Micros();   //Grab the number of milliseconds since startup
+
+    while(1){
+        if(Micros() - previousTime >= 1000000){ // 1,000,000us per second
+            previousTime = Micros();            // Update this value first to keep accurate timing
+            GPIO_Toggle(GPIOA, GPIO_PIN_5);     // (else it will drift because of the time it takes to call GPIO_Toggle)
         }
     }
 


### PR DESCRIPTION
* Added a few needed functions to ACDC_INTERRUPT
   * ```INTERRUPT_Enable```
   * ```INTERRUPT_Disable```
   * ```INTERRUPT_SetPriority```
* Added an efficient micros function to ACDC_TIMER
   * Instead of further dividing the SysTick->LOAD register by 1000 and forcing it to overflow a maximum of 72 cycles per SysTick interrupt. I found a way to use the number of milliseconds since startup and then add the value in the SysTick->VAL register to calculate the number of microseconds since startup. Now it triggers every 72,000 cycles instead of 72, freeing up a lot of CPU time.